### PR TITLE
Fix GeistSans/Mono deprecations

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
-import { GeistMono, GeistSans } from "geist/font";
+import { GeistSans } from "geist/font/sans";
+import { GeistMono } from "geist/font/mono";
 import "./globals.css";
 
 export const metadata: Metadata = {


### PR DESCRIPTION
Import from `geist/font/sans` and `/mono` instead of `geist/font`.